### PR TITLE
feat: enhance header styling

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,16 +1,20 @@
 import { SignInButton, UserButton, useUser } from "@clerk/clerk-react";
+import { Leaf } from "lucide-react";
 
 export function Header() {
   const { isSignedIn } = useUser();
 
   return (
-    <header className="flex items-center justify-between px-6 py-4 bg-white shadow">
-      <h1 className="text-3xl font-bold text-green-700">Planty Planny</h1>
+    <header className="flex items-center justify-between px-6 py-4 bg-gradient-to-r from-green-600 to-emerald-500 shadow">
+      <div className="flex items-center gap-2">
+        <Leaf className="h-8 w-8 text-white" />
+        <h1 className="text-3xl font-bold text-white">Planty Planny</h1>
+      </div>
       {isSignedIn ? (
         <UserButton afterSignOutUrl="/" />
       ) : (
         <SignInButton mode="modal">
-          <button className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors">
+          <button className="px-4 py-2 bg-white/20 text-white font-medium rounded-md border border-white/30 backdrop-blur-sm hover:bg-white/30 transition-colors">
             Sign In
           </button>
         </SignInButton>


### PR DESCRIPTION
## Summary
- add plant icon and gradient background to header
- restyle sign-in button for sleeker appearance

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953856cdc48326aba221be24d73934